### PR TITLE
[Ch03] 함수 - 진소희

### DIFF
--- a/chapter03/soheeGit/after/SearchServlet.java
+++ b/chapter03/soheeGit/after/SearchServlet.java
@@ -1,0 +1,49 @@
+package org.example;
+
+import java.io.*;
+import java.net.URLDecoder;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.*;
+import jakarta.servlet.annotation.*;
+import org.example.model.NaverAPIResultItem;
+import org.example.service.NaverAPIService;
+
+@WebServlet(name = "search", urlPatterns = "/search")
+public class SearchServlet extends HttpServlet {
+    NaverAPIService naverAPIService = new NaverAPIService();
+    // 서블릿이 처음 로드될 때 한 번만 실행되는 초기화 메서드
+    public void init() {
+    }
+
+    public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException{
+        String query = URLDecoder.decode(request.getParameter("query"), StandardCharsets.UTF_8);
+        System.out.println(query);
+        String json;
+        try {
+            List<NaverAPIResultItem> result = naverAPIService.searchByQuery(query);
+            ObjectMapper objectMapper = new ObjectMapper();
+            json = objectMapper.writeValueAsString(result);
+        } catch (InterruptedException e) {
+            response.sendError(500);
+            json = """
+                    {
+                    "error": "%s"
+                    }
+                    """.formatted(e.getMessage());
+        }
+        response.setContentType("application/json");
+        response.setCharacterEncoding("UTF-8");
+
+        // JSON 응답 전송
+        PrintWriter out = response.getWriter();
+        out.print(json);
+        out.flush();
+    }
+
+    public void destroy() {
+    }
+}

--- a/chapter03/soheeGit/after/model/NaverAPIClient.java
+++ b/chapter03/soheeGit/after/model/NaverAPIClient.java
@@ -1,0 +1,37 @@
+package org.example.model;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class NaverAPIClient {
+    private String url;
+    private String method;
+    private Map<String, String> body;
+    private Map<String, String> headers;
+
+    public NaverAPIClient(String url, String method, Map<String, String> body, String ...headers) {
+        this.url = url;
+        this.method = method;
+        this.body = body;
+        this.headers = new HashMap<>();
+        for (int i = 0; i < headers.length; i += 2) {
+            this.headers.put(headers[i], headers[i + 1]);
+        }
+    }
+
+    public String getUrl() {
+        return url;
+    }
+
+    public String getMethod() {
+        return method;
+    }
+
+    public Map<String, String> getBody() {
+        return body;
+    }
+
+    public Map<String, String> getHeaders() {
+        return headers;
+    }
+}

--- a/chapter03/soheeGit/after/model/NaverAPIResult.java
+++ b/chapter03/soheeGit/after/model/NaverAPIResult.java
@@ -1,0 +1,17 @@
+package org.example.model;
+
+import java.util.List;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class NaverAPIResult {
+    private List<NaverAPIResultItem> items;  // 여러 개의 책 항목을 담는 리스트
+
+    public List<NaverAPIResultItem> getItems() {
+        return items;
+    }
+
+    public void setItems(List<NaverAPIResultItem> items) {
+        this.items = items;
+    }
+}

--- a/chapter03/soheeGit/after/model/NaverAPIResultItem.java
+++ b/chapter03/soheeGit/after/model/NaverAPIResultItem.java
@@ -1,0 +1,70 @@
+package org.example.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class NaverAPIResultItem {
+    private String title;
+    private String link;
+    private String image;
+    private String author;
+    private String publisher;
+    private String discount;
+    private String description;
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public String getLink() {
+        return link;
+    }
+
+    public void setLink(String link) {
+        this.link = link;
+    }
+
+    public String getImage() {
+        return image;
+    }
+
+    public void setImage(String image) {
+        this.image = image;
+    }
+
+    public String getAuthor() {
+        return author;
+    }
+
+    public void setAuthor(String author) {
+        this.author = author;
+    }
+
+    public String getPublisher() {
+        return publisher;
+    }
+
+    public void setPublisher(String publisher) {
+        this.publisher = publisher;
+    }
+
+    public String getDiscount() {
+        return discount;
+    }
+
+    public void setDiscount(String discount) {
+        this.discount = discount;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+}

--- a/chapter03/soheeGit/after/service/NaverAPIService.java
+++ b/chapter03/soheeGit/after/service/NaverAPIService.java
@@ -1,0 +1,53 @@
+package org.example.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.example.model.NaverAPIClient;
+import org.example.model.NaverAPIResult;
+import org.example.model.NaverAPIResultItem;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.util.HashMap;
+import java.util.List;
+import java.util.stream.Stream;
+
+public class NaverAPIService {
+    private final String clientID;
+    private final String clientSecret;
+    private final HttpClient httpClient = HttpClient.newHttpClient();
+
+    public NaverAPIService() {
+        this.clientID = System.getenv("NAVER_CLIENT_ID");
+        this.clientSecret = System.getenv("NAVER_CLIENT_SECRET");
+        if (clientID == null || clientSecret == null) {
+            throw new RuntimeException("NaverSearchAPI: clientID or clientSecret are missing");
+        }
+    }
+
+    public List<NaverAPIResultItem> searchByQuery(String query) throws IOException, InterruptedException {
+        // https://developers.naver.com/docs/serviceapi/search/book/book.md#%EC%B1%85
+        ObjectMapper objectMapper = new ObjectMapper();
+        HashMap<String, String> body = new HashMap<>();
+        NaverAPIClient param = new NaverAPIClient(
+                "https://openapi.naver.com/v1/search/book.json?query=%s".formatted(query),
+                "GET",
+                body,
+                "X-Naver-Client-Id", clientID, "X-Naver-Client-Secret", clientSecret
+        );
+        HttpResponse<String> response = httpClient.send(HttpRequest.newBuilder()
+                .uri(URI.create(param.getUrl()))
+                .method(param.getMethod(), HttpRequest.BodyPublishers.noBody())
+                .headers(param.getHeaders().entrySet().stream()
+                        .flatMap(entry -> Stream.of(entry.getKey(), entry.getValue()))
+                        .toArray(String[]::new))
+                .build(), HttpResponse.BodyHandlers.ofString());
+        System.out.println(response.body());
+        NaverAPIResult responseBody = objectMapper.readValue(response.body(), NaverAPIResult.class);
+
+        // 검색 결과 목록 반환
+        return responseBody.getItems();
+    }
+}

--- a/chapter03/soheeGit/before/Application.java
+++ b/chapter03/soheeGit/before/Application.java
@@ -1,0 +1,53 @@
+import io.github.cdimascio.dotenv.Dotenv;
+import model.dto.NaverAPIResultItem;
+import org.apache.poi.ss.usermodel.Row;
+import org.apache.poi.ss.usermodel.Sheet;
+import org.apache.poi.ss.usermodel.Workbook;
+import org.apache.poi.xssf.usermodel.XSSFWorkbook;
+import service.search.SearchService;
+import util.logger.MyLogger;
+
+import java.io.FileOutputStream;
+import java.util.List;
+
+public class Application {
+    public static void main(String[] args) {
+        Dotenv dotenv = Dotenv.configure().ignoreIfMissing().load();
+        MyLogger logger = new MyLogger(Application.class);
+        String searchKeyword = dotenv.get("SEARCH_KEYWORD");
+        logger.info(searchKeyword);
+        SearchService searchAPI = new SearchService();
+        String filename = "%d_%s";
+        String mode = dotenv.get("MODE");
+        if (mode.isBlank()) {
+            throw new RuntimeException("mode is missing");
+        }
+        switch (mode) {
+            case "DEV":
+                filename += "_dev";
+                break;
+        }
+        try (Workbook workbook = new XSSFWorkbook(); FileOutputStream fileOut = new FileOutputStream(filename.formatted(System.currentTimeMillis(), searchKeyword) + ".xlsx")) {
+            List<NaverAPIResultItem> result = searchAPI.searchByKeyword(searchKeyword);
+//            logger.info(result.toString());
+            Sheet sheet = workbook.createSheet(searchKeyword);
+            Row headerRow = sheet.createRow(0);
+            headerRow.createCell(0).setCellValue("날짜");
+            headerRow.createCell(1).setCellValue("링크");
+            headerRow.createCell(2).setCellValue("제목");
+            headerRow.createCell(3).setCellValue("설명");
+            int i = 0;
+            for (NaverAPIResultItem item : result) {
+                Row row = sheet.createRow(++i);
+                row.createCell(0).setCellValue(item.pubDate());
+                row.createCell(1).setCellValue(item.link());
+                row.createCell(2).setCellValue(item.title());
+                row.createCell(3).setCellValue(item.description());
+            }
+            workbook.write(fileOut);
+        } catch (Exception e) {
+            logger.severe(e.getMessage());
+        }
+
+    }
+}

--- a/chapter03/soheeGit/before/dto/APIClientParam.java
+++ b/chapter03/soheeGit/before/dto/APIClientParam.java
@@ -1,0 +1,6 @@
+package model.dto;
+
+import java.util.Map;
+
+public record APIClientParam(String url, String method, Map<String, String> body, String... headers) {
+}

--- a/chapter03/soheeGit/before/dto/NaverAPIResult.java
+++ b/chapter03/soheeGit/before/dto/NaverAPIResult.java
@@ -1,0 +1,8 @@
+package model.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import java.util.List;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record NaverAPIResult(List<NaverAPIResultItem> items, String lastBuildDate) {}

--- a/chapter03/soheeGit/before/dto/NaverAPIResultItem.java
+++ b/chapter03/soheeGit/before/dto/NaverAPIResultItem.java
@@ -1,0 +1,7 @@
+package model.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record NaverAPIResultItem(String title, String link, String description, String pubDate) {
+}

--- a/chapter03/soheeGit/before/search/SearchController.java
+++ b/chapter03/soheeGit/before/search/SearchController.java
@@ -1,0 +1,48 @@
+package controller.search;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import model.dto.NaverAPIResultItem;
+import org.apache.poi.ss.usermodel.Workbook;
+import org.apache.poi.xssf.usermodel.XSSFWorkbook;
+import service.search.SearchService;
+
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.util.List;
+
+@WebServlet("/search")
+public class SearchController extends HttpServlet {
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        String searchKeyword = req.getParameter("keyword");
+        String json;
+        try {
+            SearchService searchService = new SearchService();
+            List<NaverAPIResultItem> result = searchService.searchByKeyword(searchKeyword);
+            ObjectMapper objectMapper = new ObjectMapper();
+            json = objectMapper.writeValueAsString(result);
+        } catch (Exception e) {
+            resp.sendError(500);
+            json = """
+                    {
+                    "error": "%s"
+                    }
+                    """.formatted(e.getMessage());
+        }
+
+        // 응답 설정
+        resp.setContentType("application/json");
+        resp.setCharacterEncoding("UTF-8");
+
+        // JSON 응답 전송
+        PrintWriter out = resp.getWriter();
+        out.print(json);
+        out.flush();
+    }
+}

--- a/chapter03/soheeGit/before/search/SearchService.java
+++ b/chapter03/soheeGit/before/search/SearchService.java
@@ -1,0 +1,52 @@
+package service.search;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.github.cdimascio.dotenv.Dotenv;
+import model.dto.APIClientParam;
+import model.dto.NaverAPIResult;
+import model.dto.NaverAPIResultItem;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import util.api.APIClient;
+import util.logger.MyLogger;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+
+public class SearchService {
+    private static final Logger log = LogManager.getLogger(SearchService.class);
+    private final String clientID;
+    private final String clientSecret;
+    private final MyLogger logger;
+    private final APIClient apiClient;
+
+    public SearchService() {
+        Dotenv dotenv = Dotenv.configure().ignoreIfMissing().load();
+        this.clientID = dotenv.get("NAVER_CLIENT_ID");
+        this.clientSecret = dotenv.get("NAVER_CLIENT_SECRET");
+        if (clientID == null || clientSecret == null) {
+            throw new RuntimeException("NaverSearchAPI: clientID or clientSecret are missing");
+        }
+        this.logger = new MyLogger(SearchService.class);
+        this.apiClient = new APIClient();
+//        logger.info(clientID);
+//        logger.info(clientSecret);
+        logger.info("NaverSearchAPI initailized");
+    }
+
+    public List<NaverAPIResultItem> searchByKeyword(String keyword) throws IOException, InterruptedException {
+        logger.info("Search by keyword: " + keyword);
+        // https://developers.naver.com/docs/serviceapi/search/news/news.md
+        HashMap<String, String> body = new HashMap<>();
+        APIClientParam param = new APIClientParam(
+                "https://openapi.naver.com/v1/search/news.json?query=%s".formatted(keyword),
+                "GET",
+                body
+                , "X-Naver-Client-Id", clientID, "X-Naver-Client-Secret", clientSecret
+        );
+//        logger.info(apiClient.callAPI(param));
+        ObjectMapper objectMapper = new ObjectMapper();
+        return objectMapper.readValue(apiClient.callAPI(param), NaverAPIResult.class).items();
+    }
+}

--- a/chapter03/soheeGit/before/util/api/APIClient.java
+++ b/chapter03/soheeGit/before/util/api/APIClient.java
@@ -1,0 +1,31 @@
+package util.api;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import model.dto.APIClientParam;
+import util.logger.MyLogger;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+
+public class APIClient {
+    private final MyLogger logger = new MyLogger(this.getClass());
+    private final HttpClient httpClient = HttpClient.newHttpClient();
+    public APIClient() {
+        logger.info("Initializing API client");
+    }
+    public String callAPI(APIClientParam param) throws IOException, InterruptedException {
+        logger.info("Calling API client");
+        ObjectMapper objectMapper = new ObjectMapper();
+        String body = objectMapper.writeValueAsString(param.body());
+        HttpResponse<String> response = httpClient.send(HttpRequest.newBuilder()
+                .uri(URI.create(param.url()))
+                .method(param.method(), HttpRequest.BodyPublishers.ofString(body))
+                .headers(param.headers())
+                .build(), HttpResponse.BodyHandlers.ofString());
+        logger.info("%d".formatted(response.statusCode()));
+        return response.body();
+    };
+}

--- a/chapter03/soheeGit/before/util/logger/MyLogger.java
+++ b/chapter03/soheeGit/before/util/logger/MyLogger.java
@@ -1,0 +1,41 @@
+package util.logger;
+
+import io.github.cdimascio.dotenv.Dotenv;
+
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
+
+public class MyLogger {
+    private final Logger logger;
+    public MyLogger(Class<?> clazz) {
+        Dotenv dotenv = Dotenv.configure().ignoreIfMissing().load();
+        this.logger = Logger.getLogger(clazz.getName());
+//        this.logger.setLevel(Level.parse(dotenv.get("LOG_LEVEL")));
+//        this.logger.setLevel(dotenv.get("MODE").equals("DEV") ? Level.INFO : Level.SEVERE);
+        String mode = dotenv.get("MODE");
+        if (mode.isBlank()) {
+            throw new RuntimeException("mode is missing");
+        }
+        switch (mode) {
+            case "DEV":
+                this.logger.setLevel(Level.INFO);
+                break;
+            case "PROD":
+                this.logger.setLevel(Level.SEVERE);
+                break;
+        }
+    }
+
+    public void info(String msg) {
+        LogRecord record = new LogRecord(Level.INFO, msg);
+        record.setSourceClassName(logger.getName()); // 원래 클래스 이름 설정
+        logger.log(record);
+    }
+
+    public void severe(String msg) {
+        LogRecord record = new LogRecord(Level.SEVERE, msg);
+        record.setSourceClassName(logger.getName());
+        logger.log(record);
+    }
+}


### PR DESCRIPTION
## ✨ PR 제목

`[Ch03] 함수 - 진소희`  

---

## 🖥️ 간단 소개

지난주 실습한 코드에 대해서 함수 주제에 맞게 리팩터링했습니다.

---

## 📌 개선 내용
1. Application 없애고, 서블릿 친화적으로 수정했습니다.

2. 한가지 기능을 하지 못하는 함수를 가독성 높게 다른 함수와 합쳐 수정했습니다.
- **개선 전**
```java
public List<NaverAPIResultItem> searchByKeyword(String keyword) throws IOException, InterruptedException {
        HashMap<String, String> body = new HashMap<>();
        APIClientParam param = new APIClientParam(
                "https://openapi.naver.com/v1/search/news.json?query=%s".formatted(keyword),
                "GET",
                body
                , "X-Naver-Client-Id", clientID, "X-Naver-Client-Secret", clientSecret
        );
        ObjectMapper objectMapper = new ObjectMapper();
        return objectMapper.readValue(apiClient.callAPI(param), NaverAPIResult.class).items();
}
public String callAPI(APIClientParam param) throws IOException, InterruptedException {
        ObjectMapper objectMapper = new ObjectMapper();
        String body = objectMapper.writeValueAsString(param.body());
        HttpResponse<String> response = httpClient.send(HttpRequest.newBuilder()
                .uri(URI.create(param.url()))
                .method(param.method(), HttpRequest.BodyPublishers.ofString(body))
                .headers(param.headers())
                .build(), HttpResponse.BodyHandlers.ofString());
        return response.body();
};
```  
개선 전 코드의 경우, 단순 객체 저장의 경우를 한가지 기능을 하는 함수라고 지정

- **개선 후**
```java
public List<NaverAPIResultItem> searchByQuery(String query) throws IOException, InterruptedException {
        ObjectMapper objectMapper = new ObjectMapper();
        HashMap<String, String> body = new HashMap<>();
        NaverAPIClient param = new NaverAPIClient(
                "https://openapi.naver.com/v1/search/book.json?query=%s".formatted(query),
                "GET",
                body,
                "X-Naver-Client-Id", clientID, "X-Naver-Client-Secret", clientSecret
        );
        HttpResponse<String> response = httpClient.send(HttpRequest.newBuilder()
                .uri(URI.create(param.getUrl()))
                .method(param.getMethod(), HttpRequest.BodyPublishers.noBody())
                .headers(param.getHeaders().entrySet().stream()
                        .flatMap(entry -> Stream.of(entry.getKey(), entry.getValue()))
                        .toArray(String[]::new))
                .build(), HttpResponse.BodyHandlers.ofString());
        System.out.println(response.body());
        NaverAPIResult responseBody = objectMapper.readValue(response.body(), NaverAPIResult.class);
        return responseBody.getItems();
    }
```
개선 후 코드는 단순 객체 저장의 코드와 Http요청의 코드를 한 함수로 함쳐 가독성을 높였다.

---

## 🧐 논의할 점

위의 개선 후 searchByQuery 함수 사이즈는 2가지 행위를 한다고 볼 수 있을 것 같은데, 제 생각에는 이 구조를 또 분리한다면 분리한 코드가 더 읽기 힘든 함수 코드가 될 것 같아서 합쳐놨는데, 이 부분에 대해서 논의해 보고 싶습니다.

---

## ✅ 체크리스트

- [x] PR 제목이 `[ChXX] 챕터 제목 - 이름` 형식에 맞는가?  
- [x] 코드 소개가 간단하고 명확한가?  
- [x] 개선 사항이 잘 설명되었는가?  
- [x] 논의할 점이 구체적으로 기술되었는가?